### PR TITLE
MasterClear: update UI

### DIFF
--- a/res/layout/master_clear_cm.xml
+++ b/res/layout/master_clear_cm.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
+
+    <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dip"
+            android:layout_weight="1">
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+            <!-- top section "Personal data & apps" -->
+            <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:minHeight="?android:attr/listPreferredItemHeight"
+                    android:orientation="vertical"
+                    android:paddingBottom="16dp"
+                    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                    android:paddingTop="16dp">
+
+                <TextView
+                        android:id="@+id/title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/factory_reset_instructions_title"
+                        android:textAppearance="?android:attr/textAppearanceListItem" />
+
+                <TextView
+                        android:id="@+id/summary"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/factory_reset_instructions_summary"
+                        android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+                        android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <View
+                    style="@style/SolidSettingSeparator"
+                    android:layout_marginEnd="0dp"
+                    android:layout_marginStart="0dp" />
+
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="?android:attr/listPreferredItemHeight"
+                    android:gravity="center_vertical"
+                    android:orientation="vertical"
+                    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                    android:text="@string/factory_reset_personal_content"
+                    android:textAppearance="@style/TextAppearance.CategoryTitle" />
+
+            <!-- erase stored content -->
+            <LinearLayout
+                    android:id="@+id/erase_internal_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:orientation="horizontal"
+                    android:paddingBottom="8dp"
+                    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                    android:paddingStart="?android:attr/listPreferredItemPaddingStart">
+
+                <CheckBox
+                        android:id="@+id/erase_internal"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="top"
+                        android:clickable="false"
+                        android:duplicateParentState="true"
+                        android:focusable="false"
+                        android:padding="3dp" />
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginStart="16dp"
+                        android:duplicateParentState="true"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:id="@+id/erase_storage_checkbox_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:duplicateParentState="true"
+                            android:text="@string/factory_reset_erase_stored_content"
+                            android:textAppearance="?android:attr/textAppearanceListItem"
+                            android:textStyle="bold" />
+
+                    <TextView
+                            android:id="@+id/erase_storage_checkbox_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:duplicateParentState="true"
+                            android:text="@string/factory_reset_erase_stored_content_summary"
+                            android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+                            android:textColor="?android:attr/textColorSecondary" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <!-- format sd card -->
+            <LinearLayout
+                    android:id="@+id/erase_external_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:orientation="horizontal"
+                    android:paddingBottom="8dp"
+                    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                    android:paddingTop="8dp">
+
+                <CheckBox
+                        android:id="@+id/erase_external"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="top"
+                        android:clickable="false"
+                        android:duplicateParentState="true"
+                        android:focusable="false"
+                        android:padding="3dp" />
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginStart="16dp"
+                        android:duplicateParentState="true"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:id="@+id/erase_sdcard_checkbox_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:duplicateParentState="true"
+                            android:text="@string/factory_reset_erase_sd_card"
+                            android:textAppearance="?android:attr/textAppearanceListItem"
+                            android:textStyle="bold" />
+
+                    <TextView
+                            android:id="@+id/erase_sdcard_checkbox_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:duplicateParentState="true"
+                            android:text="@string/factory_reset_erase_sd_card_summary"
+                            android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+                            android:textColor="?android:attr/textColorSecondary" />
+                </LinearLayout>
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+
+    <View style="@style/SolidSettingSeparator" />
+
+    <Button
+            android:id="@+id/initiate_master_clear"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="12dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:padding="10dp"
+            android:text="@string/master_clear_button_text"
+            android:textColor="@color/factory_reset_color"
+            android:textSize="14sp" />
+
+</LinearLayout>

--- a/res/values/cm_colors.xml
+++ b/res/values/cm_colors.xml
@@ -83,4 +83,6 @@ limitations under the License.
     <color name="contributors_cloud_selected_color">#ff5252</color>
 
     <color name="external_tile_icon_tint_color">?android:attr/colorAccent</color>
+    <color name="factory_reset_color">#FFFE412C</color>
+    <color name="divider">#ffe0e0e0</color>
 </resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1096,4 +1096,21 @@
     <string name="last_time_used_label_cm">Last time used:</string>
     <!-- label for usage time -->
     <string name="usage_time_label_cm">Usage time:</string>
+
+    <!-- SD card & phone storage settings screen, message on screen after user selects Factory data reset [CHAR LIMIT=NONE] -->
+    <string name="master_clear_desc_cm" product="tablet">This will erase all data from your tablet\'s <b>internal storage</b>, including:\n\n<li>Your device accounts</li>\n<li>System and app data and settings</li>\n<li>Downloaded apps</li></string>
+    <!-- SD card & phone storage settings screen, message on screen after user selects Factory data reset [CHAR LIMIT=NONE] -->
+    <string name="master_clear_desc_cm" product="default">This will erase all data from your phone\'s <b>internal storage</b>, including:\n\n<li>Your device accounts</li>\n<li>System and app data and settings</li>\n<li>Downloaded apps</li></string>
+
+    <!-- Factory reset strings -->
+    <string name="factory_reset_instructions_title">Personal data &amp; apps</string>
+    <string name="factory_reset_instructions_summary">This will erase all your accounts, apps, app data, and system settings on this device</string>
+    <string name="factory_reset_personal_content">Personal content</string>
+    <string name="factory_reset_erase_stored_content">Erase stored content</string>
+    <string name="factory_reset_erase_stored_content_summary">Erase music, photos, videos, and other user data stored on this device</string>
+    <string name="factory_reset_erase_stored_content_summary_forced">Erase music, photos, videos, and other user data stored on this device. \n\n<b>Content cannot be saved due to device encryption.</b></string>
+    <string name="factory_reset_erase_sd_card">Format SD card</string>
+    <string name="factory_reset_erase_sd_card_summary">Erase all data on the SD card, including music and photos</string>
+    <string name="factory_reset_warning_text_reset_now">RESET NOW</string>
+    <string name="factory_reset_warning_text_message">All your accounts, apps, app data, and system settings will be removed from this device. This cannot be reversed.</string>
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -371,6 +371,10 @@
         <item name="android:layout_height">1dp</item>
     </style>
 
+    <style name="SolidSettingSeparator" parent="@style/settingSeparator">
+        <item name="android:background">@color/divider</item>
+    </style>
+
     <style name="floating_action_button">
         <item name="android:layout_width">@dimen/fab_size</item>
         <item name="android:layout_height">@dimen/fab_size</item>

--- a/src/com/android/settings/MasterClear.java
+++ b/src/com/android/settings/MasterClear.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 The Android Open Source Project
+ * Copyright (C) 2015 The CyanogenMod Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +17,6 @@
 
 package com.android.settings;
 
-import android.accounts.Account;
-import android.accounts.AccountManager;
-import android.accounts.AuthenticatorDescription;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
@@ -27,6 +25,9 @@ import android.content.pm.PackageManager;
 import android.content.pm.UserInfo;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Process;
@@ -39,7 +40,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import com.android.internal.logging.MetricsLogger;
 
@@ -60,11 +60,14 @@ public class MasterClear extends InstrumentedFragment {
 
     private static final int KEYGUARD_REQUEST = 55;
 
-    static final String ERASE_EXTERNAL_EXTRA = "erase_sd";
+    //must match MasterClearReceiver.java extra
+    public static final String EXTRA_WIPE_MEDIA = "wipe_media";
 
     private View mContentView;
     private Button mInitiateButton;
     private View mExternalStorageContainer;
+    private View mInternalStorageContainer;
+    private CheckBox mInternalStorage;
     private CheckBox mExternalStorage;
 
     /**
@@ -97,10 +100,9 @@ public class MasterClear extends InstrumentedFragment {
     }
 
     private void showFinalConfirmation() {
-        Bundle args = new Bundle();
-        args.putBoolean(ERASE_EXTERNAL_EXTRA, mExternalStorage.isChecked());
-        ((SettingsActivity) getActivity()).startPreferencePanel(MasterClearConfirm.class.getName(),
-                args, R.string.master_clear_confirm_title, null, null, 0);
+        MasterClearConfirm.createInstance(mInternalStorage.isChecked(),
+                mExternalStorage.isChecked()) .show(getFragmentManager(),
+                MasterClearConfirm.class.getSimpleName());
     }
 
     /**
@@ -132,150 +134,78 @@ public class MasterClear extends InstrumentedFragment {
     private void establishInitialState() {
         mInitiateButton = (Button) mContentView.findViewById(R.id.initiate_master_clear);
         mInitiateButton.setOnClickListener(mInitiateListener);
+        mInternalStorage = (CheckBox) mContentView.findViewById(R.id.erase_internal);
+        mInternalStorageContainer = mContentView.findViewById(R.id.erase_internal_container);
         mExternalStorageContainer = mContentView.findViewById(R.id.erase_external_container);
         mExternalStorage = (CheckBox) mContentView.findViewById(R.id.erase_external);
 
-        /*
-         * If the external storage is emulated, it will be erased with a factory
-         * reset at any rate. There is no need to have a separate option until
-         * we have a factory reset that only erases some directories and not
-         * others. Likewise, if it's non-removable storage, it could potentially have been
-         * encrypted, and will also need to be wiped.
+        boolean hasExternalStorage = false;
+
+        /**
+         * Here we do some logic to ensure the proper states are initialized.
+         * - hide internal memory section if device doesn't support it
+         * - force internal memory to be erased if the device is encrypted
+         * - show and hide the sd card section if the device supports this (and its inserted)
+         * TODO: mutli SD card support: no devices we support have this, but that might change
          */
-        boolean isExtStorageEmulated = Environment.isExternalStorageEmulated();
-        if (isExtStorageEmulated
-                || (!Environment.isExternalStorageRemovable() && isExtStorageEncrypted())) {
-            mExternalStorageContainer.setVisibility(View.GONE);
 
-            final View externalOption = mContentView.findViewById(R.id.erase_external_option_text);
-            externalOption.setVisibility(View.GONE);
-
-            final View externalAlsoErased = mContentView.findViewById(R.id.also_erases_external);
-            externalAlsoErased.setVisibility(View.VISIBLE);
-
-            // If it's not emulated, it is on a separate partition but it means we're doing
-            // a force wipe due to encryption.
-            mExternalStorage.setChecked(!isExtStorageEmulated);
-        } else {
-            mExternalStorageContainer.setOnClickListener(new View.OnClickListener() {
-
+        if (Environment.isExternalStorageEmulated()) {
+            // we may have to force wipe internal storage due to encryption.
+            mInternalStorageContainer.setEnabled(!isExtStorageEncrypted()
+                    && !Environment.isExternalStorageRemovable());
+            mInternalStorageContainer.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mExternalStorage.toggle();
+                    mInternalStorage.toggle();
                 }
             });
+            if (!mInternalStorageContainer.isEnabled()) {
+                // force internal wipe
+                mInternalStorage.setChecked(true);
+                TextView internalSummaryText = (TextView) mContentView.findViewById(
+                        R.id.erase_storage_checkbox_description);
+                internalSummaryText.setText(
+                        R.string.factory_reset_erase_stored_content_summary_forced);
+            }
+        } else {
+            // there's no storage emulation; hide internal storage
+            mInternalStorageContainer.setVisibility(View.GONE);
+
+            // primary storage can be removed. but does it exist?
         }
 
-        final UserManager um = (UserManager) getActivity().getSystemService(Context.USER_SERVICE);
-        loadAccountList(um);
+        hasExternalStorage = Environment.isExternalStorageRemovable()
+                && Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED);
+        mExternalStorageContainer.setVisibility(hasExternalStorage ? View.VISIBLE : View.GONE);
+        mExternalStorageContainer.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mExternalStorage.toggle();
+            }
+        });
+
         StringBuffer contentDescription = new StringBuffer();
-        View masterClearContainer = mContentView.findViewById(R.id.master_clear_container);
-        getContentDescription(masterClearContainer, contentDescription);
-        masterClearContainer.setContentDescription(contentDescription);
+        getContentDescription(mInternalStorageContainer, contentDescription);
+        mInternalStorageContainer.setContentDescription(contentDescription);
     }
 
     private void getContentDescription(View v, StringBuffer description) {
-       if (v instanceof ViewGroup) {
-           ViewGroup vGroup = (ViewGroup) v;
-           for (int i = 0; i < vGroup.getChildCount(); i++) {
-               View nextChild = vGroup.getChildAt(i);
-               getContentDescription(nextChild, description);
-           }
-       } else if (v instanceof TextView) {
-           TextView vText = (TextView) v;
-           description.append(vText.getText());
-           description.append(","); // Allow Talkback to pause between sections.
-       }
+        if (v instanceof ViewGroup) {
+            ViewGroup vGroup = (ViewGroup) v;
+            for (int i = 0; i < vGroup.getChildCount(); i++) {
+                View nextChild = vGroup.getChildAt(i);
+                getContentDescription(nextChild, description);
+            }
+        } else if (v instanceof TextView) {
+            TextView vText = (TextView) v;
+            description.append(vText.getText());
+            description.append(","); // Allow Talkback to pause between sections.
+        }
     }
 
     private boolean isExtStorageEncrypted() {
         String state = SystemProperties.get("vold.decrypt");
         return !"".equals(state);
-    }
-
-    private void loadAccountList(final UserManager um) {
-        View accountsLabel = mContentView.findViewById(R.id.accounts_label);
-        LinearLayout contents = (LinearLayout)mContentView.findViewById(R.id.accounts);
-        contents.removeAllViews();
-
-        Context context = getActivity();
-        final List<UserInfo> profiles = um.getProfiles(UserHandle.myUserId());
-        final int profilesSize = profiles.size();
-
-        AccountManager mgr = AccountManager.get(context);
-
-        LayoutInflater inflater = (LayoutInflater)context.getSystemService(
-                Context.LAYOUT_INFLATER_SERVICE);
-
-        int accountsCount = 0;
-        for (int profileIndex = 0; profileIndex < profilesSize; profileIndex++) {
-            final UserInfo userInfo = profiles.get(profileIndex);
-            final int profileId = userInfo.id;
-            final UserHandle userHandle = new UserHandle(profileId);
-            Account[] accounts = mgr.getAccountsAsUser(profileId);
-            final int N = accounts.length;
-            if (N == 0) {
-                continue;
-            }
-            accountsCount += N;
-
-            AuthenticatorDescription[] descs = AccountManager.get(context)
-                    .getAuthenticatorTypesAsUser(profileId);
-            final int M = descs.length;
-
-            View titleView = Utils.inflateCategoryHeader(inflater, contents);
-            final TextView titleText = (TextView) titleView.findViewById(android.R.id.title);
-            titleText.setText(userInfo.isManagedProfile() ? R.string.category_work
-                    : R.string.category_personal);
-            contents.addView(titleView);
-
-            for (int i = 0; i < N; i++) {
-                Account account = accounts[i];
-                AuthenticatorDescription desc = null;
-                for (int j = 0; j < M; j++) {
-                    if (account.type.equals(descs[j].type)) {
-                        desc = descs[j];
-                        break;
-                    }
-                }
-                if (desc == null) {
-                    Log.w(TAG, "No descriptor for account name=" + account.name
-                            + " type=" + account.type);
-                    continue;
-                }
-                Drawable icon = null;
-                try {
-                    if (desc.iconId != 0) {
-                        Context authContext = context.createPackageContextAsUser(desc.packageName,
-                                0, userHandle);
-                        icon = context.getPackageManager().getUserBadgedIcon(
-                                authContext.getDrawable(desc.iconId), userHandle);
-                    }
-                } catch (PackageManager.NameNotFoundException e) {
-                    Log.w(TAG, "Bad package name for account type " + desc.type);
-                } catch (Resources.NotFoundException e) {
-                    Log.w(TAG, "Invalid icon id for account type " + desc.type, e);
-                }
-                if (icon == null) {
-                    icon = context.getPackageManager().getDefaultActivityIcon();
-                }
-
-                TextView child = (TextView)inflater.inflate(R.layout.master_clear_account,
-                        contents, false);
-                child.setText(account.name);
-                child.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
-                contents.addView(child);
-            }
-        }
-
-        if (accountsCount > 0) {
-            accountsLabel.setVisibility(View.VISIBLE);
-            contents.setVisibility(View.VISIBLE);
-        }
-        // Checking for all other users and their profiles if any.
-        View otherUsers = mContentView.findViewById(R.id.other_users_present);
-        final boolean hasOtherUsers = (um.getUserCount() - profilesSize) > 0;
-        otherUsers.setVisibility(hasOtherUsers ? View.VISIBLE : View.GONE);
     }
 
     @Override
@@ -287,7 +217,7 @@ public class MasterClear extends InstrumentedFragment {
             return inflater.inflate(R.layout.master_clear_disallowed_screen, null);
         }
 
-        mContentView = inflater.inflate(R.layout.master_clear, null);
+        mContentView = inflater.inflate(R.layout.master_clear_cm, null);
 
         establishInitialState();
         return mContentView;

--- a/src/com/android/settings/MasterClearConfirm.java
+++ b/src/com/android/settings/MasterClearConfirm.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 The Android Open Source Project
+ * Copyright (C) 2015 The CyanogenMod Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +17,13 @@
 
 package com.android.settings;
 
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.os.AsyncTask;
 import android.provider.Settings;
@@ -28,10 +34,7 @@ import com.android.internal.logging.MetricsLogger;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.UserManager;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.Button;
+import android.service.persistentdata.PersistentDataBlockManager;
 import android.widget.TextView;
 
 /**
@@ -44,114 +47,174 @@ import android.widget.TextView;
  *
  * This is the confirmation screen.
  */
-public class MasterClearConfirm extends InstrumentedFragment {
+public class MasterClearConfirm extends DialogFragment {
 
-    private View mContentView;
-    private boolean mEraseSdCard;
+    private static final String REASON_MASTER_CLEAR_CONFIRM = "MasterClearConfirm";
+
+    private boolean mEraseInternal;
+    private boolean mEraseExternal;
+
+    public static class FrpDialog extends DialogFragment {
+
+        private int mOriginalOrientation;
+
+        public static FrpDialog createInstance(boolean wipeInternal, boolean wipeExternal) {
+            Bundle b = new Bundle();
+            b.putBoolean(MasterClear.EXTRA_WIPE_MEDIA, wipeInternal);
+            b.putBoolean(Intent.EXTRA_WIPE_EXTERNAL_STORAGE, wipeExternal);
+            FrpDialog fragment = new FrpDialog();
+            fragment.setArguments(b);
+
+            return fragment;
+        }
+
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            final ProgressDialog progressDialog = new ProgressDialog(getActivity(), getTheme());
+            progressDialog.setIndeterminate(true);
+            progressDialog.setCancelable(false);
+            progressDialog.setTitle(getActivity().getString(R.string.master_clear_progress_title));
+            progressDialog.setMessage(getActivity().getString(R.string.master_clear_progress_text));
+            return progressDialog;
+        }
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            setShowsDialog(true);
+            setCancelable(false);
+        }
+
+        @Override
+        public void onStart() {
+            super.onStart();
+
+            // need to prevent orientation changes as we're about to go into
+            // a long IO request, so we won't be able to access inflate resources on flash
+            mOriginalOrientation = getActivity().getRequestedOrientation();
+            getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+        }
+
+        @Override
+        public void onStop() {
+            super.onStop();
+            getActivity().setRequestedOrientation(mOriginalOrientation);
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            new AsyncTask<Void, Void, Void>() {
+
+                Context mContext;
+                boolean mWipeMedia;
+                boolean mWipeExternal;
+
+                @Override
+                protected void onPreExecute() {
+                    mContext = getActivity().getApplicationContext();
+                    mWipeMedia = getArguments().getBoolean(MasterClear.EXTRA_WIPE_MEDIA);
+                    mWipeExternal = getArguments().getBoolean(Intent.EXTRA_WIPE_EXTERNAL_STORAGE);
+                }
+
+                @Override
+                protected Void doInBackground(Void... params) {
+                    final PersistentDataBlockManager pdbManager = (PersistentDataBlockManager)
+                            mContext.getSystemService(Context.PERSISTENT_DATA_BLOCK_SERVICE);
+                    if (pdbManager != null) pdbManager.wipe();
+                    return null;
+                }
+
+                @Override
+                protected void onPostExecute(Void aVoid) {
+                    FrpDialog.this.dismissAllowingStateLoss();
+                    doMasterClear(mContext, mWipeMedia, mWipeExternal);
+                }
+            }.execute();
+        }
+    }
+
+    public static MasterClearConfirm createInstance(boolean wipeInternal, boolean wipeExternal) {
+        Bundle b = new Bundle();
+        b.putBoolean(MasterClear.EXTRA_WIPE_MEDIA, wipeInternal);
+        b.putBoolean(Intent.EXTRA_WIPE_EXTERNAL_STORAGE, wipeExternal);
+        MasterClearConfirm fragment = new MasterClearConfirm();
+        fragment.setArguments(b);
+
+        return fragment;
+    }
 
     /**
      * The user has gone through the multiple confirmation, so now we go ahead
      * and invoke the Checkin Service to reset the device to its factory-default
      * state (rebooting in the process).
      */
-    private Button.OnClickListener mFinalClickListener = new Button.OnClickListener() {
-
-        public void onClick(View v) {
-            if (Utils.isMonkeyRunning()) {
-                return;
-            }
-
-            final PersistentDataBlockManager pdbManager = (PersistentDataBlockManager)
-                    getActivity().getSystemService(Context.PERSISTENT_DATA_BLOCK_SERVICE);
-
-            if (pdbManager != null && !pdbManager.getOemUnlockEnabled() &&
-                    Settings.Global.getInt(getActivity().getContentResolver(),
-                            Settings.Global.DEVICE_PROVISIONED, 0) != 0) {
-                // if OEM unlock is enabled, this will be wiped during FR process. If disabled, it
-                // will be wiped here, unless the device is still being provisioned, in which case
-                // the persistent data block will be preserved.
-                new AsyncTask<Void, Void, Void>() {
-                    int mOldOrientation;
-                    ProgressDialog mProgressDialog;
-
-                    @Override
-                    protected Void doInBackground(Void... params) {
-                        pdbManager.wipe();
-                        return null;
-                    }
-
-                    @Override
-                    protected void onPostExecute(Void aVoid) {
-                        mProgressDialog.hide();
-                        getActivity().setRequestedOrientation(mOldOrientation);
-                        doMasterClear();
-                    }
-
-                    @Override
-                    protected void onPreExecute() {
-                        mProgressDialog = getProgressDialog();
-                        mProgressDialog.show();
-
-                        // need to prevent orientation changes as we're about to go into
-                        // a long IO request, so we won't be able to access inflate resources on flash
-                        mOldOrientation = getActivity().getRequestedOrientation();
-                        getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
-                    }
-                }.execute();
-            } else {
-                doMasterClear();
-            }
+    private void onResetConfirmed() {
+        if (Utils.isMonkeyRunning()) {
+            return;
         }
 
-        private ProgressDialog getProgressDialog() {
-            final ProgressDialog progressDialog = new ProgressDialog(getActivity());
-            progressDialog.setIndeterminate(true);
-            progressDialog.setCancelable(false);
-            progressDialog.setTitle(
-                    getActivity().getString(R.string.master_clear_progress_title));
-            progressDialog.setMessage(
-                    getActivity().getString(R.string.master_clear_progress_text));
-            return progressDialog;
-        }
-    };
+        final PersistentDataBlockManager pdbManager = (PersistentDataBlockManager)
+                getActivity().getSystemService(Context.PERSISTENT_DATA_BLOCK_SERVICE);
 
-    private void doMasterClear() {
+        if (pdbManager != null && !pdbManager.getOemUnlockEnabled()) {
+            // if OEM unlock is enabled, this will be wiped during FR process.
+            FrpDialog.createInstance(mEraseInternal, mEraseExternal)
+                    .show(getFragmentManager(), "frp_dialog");
+        } else {
+            doMasterClear(getActivity(), mEraseInternal, mEraseExternal);
+        }
+    }
+
+    private static void doMasterClear(Context context, boolean eraseInternal,
+                                      boolean eraseExternal) {
         Intent intent = new Intent(Intent.ACTION_MASTER_CLEAR);
         intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
-        intent.putExtra(Intent.EXTRA_REASON, "MasterClearConfirm");
-        intent.putExtra(Intent.EXTRA_WIPE_EXTERNAL_STORAGE, mEraseSdCard);
-        getActivity().sendBroadcast(intent);
+        intent.putExtra(MasterClear.EXTRA_WIPE_MEDIA, eraseInternal);
+        intent.putExtra(Intent.EXTRA_WIPE_EXTERNAL_STORAGE, eraseExternal);
+        intent.putExtra(Intent.EXTRA_REASON, REASON_MASTER_CLEAR_CONFIRM);
+        context.sendBroadcast(intent);
         // Intent handling is asynchronous -- assume it will happen soon.
     }
 
-    /**
-     * Configure the UI for the final confirmation interaction
-     */
-    private void establishFinalConfirmationState() {
-        mContentView.findViewById(R.id.execute_master_clear)
-                .setOnClickListener(mFinalClickListener);
-    }
-
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
         if (UserManager.get(getActivity()).hasUserRestriction(
                 UserManager.DISALLOW_FACTORY_RESET)) {
-            return inflater.inflate(R.layout.master_clear_disallowed_screen, null);
+            return new AlertDialog.Builder(getActivity())
+                    .setMessage(R.string.master_clear_not_available)
+                    .create();
         }
-        mContentView = inflater.inflate(R.layout.master_clear_confirm, null);
-        establishFinalConfirmationState();
-        setAccessibilityTitle();
-        return mContentView;
+        final AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.device_reset_title)
+                .setMessage(getString(R.string.factory_reset_warning_text_message))
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.factory_reset_warning_text_reset_now,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                onResetConfirmed();
+                            }
+                        })
+                .create();
+        alertDialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialog) {
+                AlertDialog d = (AlertDialog) dialog;
+                d.getButton(DialogInterface.BUTTON_POSITIVE)
+                        .setTextColor(getResources().getColor(R.color.factory_reset_color));
+            }
+        });
+
+        return alertDialog;
     }
 
     private void setAccessibilityTitle() {
         CharSequence currentTitle = getActivity().getTitle();
-        TextView confirmationMessage =
-                (TextView) mContentView.findViewById(R.id.master_clear_confirm);
+        CharSequence confirmationMessage = getText(R.string.factory_reset_warning_text_reset_now);
         if (confirmationMessage != null) {
             String accessibileText = new StringBuilder(currentTitle).append(",").append(
-                    confirmationMessage.getText()).toString();
+                    confirmationMessage).toString();
             getActivity().setTitle(Utils.createAccessibleSequence(currentTitle, accessibileText));
         }
     }
@@ -159,14 +222,15 @@ public class MasterClearConfirm extends InstrumentedFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (getActivity() != null) {
+            getActivity().setTitle(R.string.device_reset_title);
+            setAccessibilityTitle();
+        }
 
         Bundle args = getArguments();
-        mEraseSdCard = args != null
-                && args.getBoolean(MasterClear.ERASE_EXTERNAL_EXTRA);
-    }
+        mEraseInternal = args != null && args.getBoolean(MasterClear.EXTRA_WIPE_MEDIA, false);
+        mEraseExternal = args != null && args.getBoolean(Intent.EXTRA_WIPE_EXTERNAL_STORAGE, false);
 
-    @Override
-    protected int getMetricsCategory() {
-        return MetricsLogger.MASTER_CLEAR_CONFIRM;
+        setShowsDialog(true);
     }
 }


### PR DESCRIPTION
Also squashed the following related commits from 12.1:

    MasterClear: fix FRP wipe crash

    Requesting setRequestedOrientation() right after showing a custom dialog
    in a DialogFragment does not play nice. It forces the activity to be
    recreated instantly, so when the task finishes, there original activity
    the AsyncTask is tied to is no longer valid.

    However, if we let fragment manager keep track of all the dialogs, it
    doesn't break the expected behavior.

    REF: CYNGNOS-427
    Change-Id: I0609816182a6b5319d2a88ff0075d53e3c2fed16
    Signed-off-by: Roman Birg <roman@cyngn.com>

    Settings: make FRP wipe dialog not cancelable

    User should not be able to interact with the screen after the process
    has started. Otherwise we can get in a bad state and never perform the
    factory reset.

    Ref: CYNGNOS-427
    Change-Id: I197a6ca70487a33b0ce402fda7a2d58828e8e1bb
    Signed-off-by: Roman Birg <roman@cyngn.com>

    Settings: don't crash when dismissing FRP

    If the user has pressed home while the dailog is up, there may be
    nothing to dismiss by the time the task finishes.

    Ref: CYNGNOS-427
    Change-Id: Ic4fdec1ecb32f88181feba4bfd3eb337b1b61efd
    Signed-off-by: Roman Birg <roman@cyngn.com>

    Settings: continue factory reset if user leaves activity

    If the FRP dialog is up, and the user presses the home button, the FRP
    task will finish, and then try to use the activity context to initiate
    the wipe, and the fragment to retreive args, both of which is no longer
    valid.

    Cache all variables before the task begins, and use the application
    context to complete the calls.

    Ref: CYNGNOS-427

    Change-Id: I5c8b286195a0b57fd879a1022d64ea548363b925
    Signed-off-by: Roman Birg <roman@cyngn.com>

Ref: Settings-86

Change-Id: I759de586bf5cb8558d42575d08df63aaf84fffa6
Signed-off-by: Roman Birg <roman@cyngn.com>